### PR TITLE
Println deprecated in Swift 2, added name

### DIFF
--- a/swift.html.markdown
+++ b/swift.html.markdown
@@ -4,6 +4,7 @@ contributors:
   - ["Grant Timmerman", "http://github.com/grant"]
   - ["Christopher Bess", "http://github.com/cbess"]
   - ["Joey Huang", "http://github.com/kamidox"]  
+  - ["Anthony Nguyen", "http://github.com/anthonyn60"]
 filename: learnswift.swift
 ---
 


### PR DESCRIPTION
Println will no longer work in Swift 2. Switched all println methods to print.
